### PR TITLE
Add binutils for ipk extraction

### DIFF
--- a/cross.dockerfile
+++ b/cross.dockerfile
@@ -51,7 +51,7 @@ FROM robotpy/roborio-cpp-cross-ubuntu:2020-18.04 AS crossenv
 RUN set -xe; \
     apt-get update; \
     apt-get install -y \
-        libreadline5 libncursesw5 libssl1.1 \
+        binutils libreadline5 libncursesw5 libssl1.1 \
         libsqlite3-0 libgdbm5 libbz2-1.0 libffi6 zlib1g; \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Binutils adds "ar" which can be used to extract control.tar.gz, data.tar.gz and debina-binary files. From there use tar to extract the gz files (tar -zxvf <file>)

Addresses #2 