### PR TITLE
Add ipk install script. Fix distutils vars. Add wheel.

### DIFF
--- a/cross.dockerfile
+++ b/cross.dockerfile
@@ -57,12 +57,17 @@ RUN set -xe; \
 
 COPY --from=pycompile /usr/local /usr/local
 COPY --from=pycompile /build/crosspy /build/crosspy
+COPY opkg-venv /usr/local/bin
 
 RUN set -xe; \
+    chmod a+x /usr/local/bin/opkg-venv; \
     ldconfig; \
     python3.8 -m pip install crossenv; \
-    python3.8 -m crossenv /build/crosspy/bin/python3.8 /build/venv --sysroot=$(arm-frc2020-linux-gnueabi-gcc -print-sysroot);
+    python3.8 -m crossenv /build/crosspy/bin/python3.8 /build/venv --sysroot=$(arm-frc2020-linux-gnueabi-gcc -print-sysroot); \
+    /build/venv/bin/cross-pip install wheel;
 
+ENV LDSHARED="arm-frc2020-linux-gnueabi-gcc -pthread -shared"
+ENV CC="arm-frc2020-linux-gnueabi-gcc -pthread"
 ENV RPYBUILD_PARALLEL=1
 
 COPY crossenv.cfg /build/venv/crossenv.cfg

--- a/opkg-venv
+++ b/opkg-venv
@@ -1,0 +1,11 @@
+#!/bin/bash
+PKG=$(realpath $1)
+BASENAME=${1##*/}
+# # Create tmp unpackage dir
+TEMP_DIR=`mktemp -d -t $BASENAME-XXXXXXXXXX`
+echo $TEMP_DIR
+cd $TEMP_DIR
+cp $PKG ./
+ar -x $BASENAME
+tar -zxvf data.tar.gz
+cp -R usr/local/* /usr/local/arm-frc2020-linux-gnueabi/


### PR DESCRIPTION
Addresses #2.

Builds cscore now
```
cd build
. ./venv/activate
mkdir ipks
wget -O ipks/opencv4-dev.ipk https://www.tortall.net/~robotpy/feeds/2020/opencv4-dev_4.2.0-r1_cortexa9-vfpv3.ipk
wget -O ipks/opencv4.ipk https://www.tortall.net/~robotpy/feeds/2020/opencv4_4.2.0-r1_cortexa9-vfpv3.ipk
opkg-venv ipks/opencv4-dev.ipk
opkg-venv ipks/opencv4.ipk

```
small hack on next line to move opencv include folder to correct position. May not be needed for other packages.
```
mv /usr/local/arm-frc2020-linux-gnueabi/include/opencv4/opencv2 /usr/local/arm-frc2020-linux-gnueabi/include/
git clone https://github.com/robotpy/robotpy-cscore.git
cd robotpy-cscore
python setup.py bdist_wheel
```